### PR TITLE
fix: default stacksize

### DIFF
--- a/.github/workflows/zeroperl.yml
+++ b/.github/workflows/zeroperl.yml
@@ -372,8 +372,8 @@ jobs:
 
           echo "Stripping comments from .pl and .pm files in /zeroperl..."
           for f in $(find /zeroperl -type f \( -name '*.pl' -o -name '*.pm' \)); do
-            echo "Stripping $f..."
-            perlstrip -s "$f"
+             echo "Stripping $f with -s..."
+             perlstrip -s "$f"
           done
 
           mkdir ${{ github.workspace }}/gen
@@ -383,11 +383,11 @@ jobs:
           current_dir=$(pwd)
 
           cd ${{ github.workspace }}/stubs
-          wasic -O3 -c machine.c -o machine.o
-          wasic -O3 -c runtime.c -o runtime.o
-          wasic -O3 -c setjmp.c -o setjmp.o
-          wasic -O3 -c machine_core.S -o machine_core.o
-          wasic -O3 -c setjmp_core.S -o setjmp_core.o
+          wasic -O3 -c machine.c -o machine.o #-DASYNCJMP_ENABLE_DEBUG_LOG
+          wasic -O3 -c runtime.c -o runtime.o #-DASYNCJMP_ENABLE_DEBUG_LOG
+          wasic -O3 -c setjmp.c -o setjmp.o #-DASYNCJMP_ENABLE_DEBUG_LOG
+          wasic -O3 -c machine_core.S -o machine_core.o #-DASYNCJMP_ENABLE_DEBUG_LOG
+          wasic -O3 -c setjmp_core.S -o setjmp_core.o #-DASYNCJMP_ENABLE_DEBUG_LOG
           "${WASI_SDK_PATH}/bin/llvm-ar" crs libasyncjmp.a \
           machine.o runtime.o setjmp.o \
           machine_core.o setjmp_core.o
@@ -398,6 +398,7 @@ jobs:
             -o zeroperl_unopt \
             -flto=full \
             -O3 \
+            -z stack-size=524288 -Wl,--initial-memory=24772608 \
             -static \
             -DNO_MATHOMS \
             -D_WASI_EMULATED_PROCESS_CLOCKS -lwasi-emulated-process-clocks \


### PR DESCRIPTION
The default stacksize of the WASI SDK was causing memory issues with Perl. Bumping it to 512kb seems to have resolved them.